### PR TITLE
riscv: remove `-mgeneral-regs-only` flags

### DIFF
--- a/gnuefi/GNUmakefile
+++ b/gnuefi/GNUmakefile
@@ -116,8 +116,7 @@ ifeq ($(ARCH),riscv64)
         override CFLAGS += -march=rv64imac
     endif
     override CFLAGS += \
-        -mabi=lp64 \
-        -mgeneral-regs-only
+        -mabi=lp64
 endif
 
 override OBJS := crt0-efi-$(ARCH).o reloc_$(ARCH).o


### PR DESCRIPTION
This flag is not required and is not recognized by GCC.